### PR TITLE
Add count and offset parameters

### DIFF
--- a/Runtime/UnityWebRequestSketchfabModelList.cs
+++ b/Runtime/UnityWebRequestSketchfabModelList.cs
@@ -29,6 +29,9 @@ public static class UnityWebRequestSketchfabModelList
         public int? archives_max_texture_count;
         public int? archives_texture_max_resolution;
 
+        public int? count;
+        public int? offset;
+
         public string UrlEcnode()
         {
             List<string> urlParameters = new List<string>();
@@ -136,6 +139,16 @@ public static class UnityWebRequestSketchfabModelList
             if (archives_texture_max_resolution != null)
             {
                 urlParameters.Add($"archives_texture_max_resolution={archives_texture_max_resolution.Value}");
+            }
+
+            if (count != null && count > 0)
+            {
+                urlParameters.Add($"count={count.Value}");
+            }
+
+            if (offset != null && offset > 0)
+            {
+                urlParameters.Add($"offset={offset.Value}");
             }
 
             return string.Join("&", urlParameters);


### PR DESCRIPTION
Count and offset parameters allow to set the amount of items and offset in the pagination of  the web request results.

I used this to fetch a random model, inspired by
https://github.com/sketchfab/experiments/blob/master/random/index.html

Not sure if the parameters are deprecated, because I didn't find the parameters in the Sketchfab documentation. It worked for me though.

(My very first time forking a repo and opening a pull request. Let me know if this is an unreasonable change :) )